### PR TITLE
Reland Typeassert, with convert on construct

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Unityper"
 uuid = "a7c27f48-0311-42f6-a7f8-2c11e75eb415"
 authors = ["Yingbo Ma <mayingbo5@gmail.com>, Chris Elrod <elrodc@gmail.com>, and contributors"]
-version = "0.1.4"
+version = "0.1.5"
 
 [deps]
 ConstructionBase = "187b0558-2788-49d3-abe0-74a17ed4e7c9"

--- a/src/compactify.jl
+++ b/src/compactify.jl
@@ -385,9 +385,9 @@ function _compactify(mod, block; debug=false, show_methods=true)
                     if S2 === S
                         is_native = true
                         if isany # don't call simulate_type for Anys
-                            push!(constructor_body, :($newname = $oldname))
+                            push!(constructor_body, :($newname = convert($oldtype,$oldname)))
                         else
-                            push!(constructor_body, :($newname = $simulate_type($newtype, $oldname)))
+                            push!(constructor_body, :($newname = $simulate_type($newtype, convert($oldtype,$oldname))))
                         end
                         break
                     end

--- a/test/compactify.jl
+++ b/test/compactify.jl
@@ -53,6 +53,8 @@ b = B(a=12, b=2.0, d=2+1im)
 @test b.a === 12
 @test b.b === 2.0
 @test b.d === 2 + 1im
+@test B(a=12.0,b=2.0).a == 12
+@test_throws InexactError B(a=12.5,b=2.0)
 
 c = C()
 @test c.b === 2.0

--- a/test/compactify.jl
+++ b/test/compactify.jl
@@ -60,13 +60,13 @@ c = C()
 @test c.b === 2.0
 @test !c.d
 @test c.e === 3.0
-@test c.k === 1 + 2im
+@test c.k === convert(Complex{Real}, 1 + 2im)
 
 c = C(b=8.0, d=true, e=5.0, k=10+10im)
 @test c.b === 8.0
 @test c.d
 @test c.e === 5.0
-@test c.k === 10 + 10im
+@test c.k === convert(Complex{Real}, 10 + 10im)
 
 d = D()
 @test d.b == "hi"
@@ -167,13 +167,13 @@ c = C1()
 @test c.b === 2.0
 @test !c.d
 @test c.e === 3.0
-@test c.k === 1 + 2im
+@test c.k === convert(Complex{Real}, 1 + 2im)
 
 c = C1(b=8.0, d=true, e=5.0, k=10+10im)
 @test c.b === 8.0
 @test c.d
 @test c.e === 5.0
-@test c.k === 10 + 10im
+@test c.k === convert(Complex{Real}, 10 + 10im)
 
 d = D1()
 @test d.b == "hi"


### PR DESCRIPTION
I added two tests that fail on Unityper master, and should exemplify the sort of problem that caused the original typeassert commit to be reverted.